### PR TITLE
More clone impls and make Claim.sub public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Make `Claim.sub` public.
+- Implement `Clone` for `JWK`, `JWKS`, and `Claim`.
+
 ## [0.1.0] - 2021-02-26
 ### Changed
 - `provider::token_data` renamed to `provider::verify_token`.

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -108,9 +108,10 @@ pub fn from_str(data: &str) -> Provider {
     serde_json::from_str::<Provider>(&data).unwrap()
 }
 
+#[non_exhaustive]
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
-    sub: String,
+    pub sub: String,
 }
 
 /// Deserialize token data

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -73,7 +73,7 @@ impl Provider {
     }
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Clone)]
 pub struct JWK {
     kty: String,
     alg: String,
@@ -86,7 +86,7 @@ pub struct JWK {
     pub key: String,
 }
 
-#[derive(serde::Deserialize, Debug)]
+#[derive(serde::Deserialize, Debug, Clone)]
 pub struct JWKS {
     pub keys: Vec<JWK>,
 }
@@ -108,7 +108,7 @@ pub fn from_str(data: &str) -> Provider {
     serde_json::from_str::<Provider>(&data).unwrap()
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Claims {
     sub: String,
 }


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Some limitations I ran into while building something using tame-oidc.

- Make `Claim.sub` public but `non_exhaustive` so we can add more fields in the future.
- Implement `Clone` for `JWK`, `JWKS`, and `Claim`.
