### PR TITLE
Add PKCE support to the OIDC flow - breaks current API

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,7 @@
 use thiserror::Error;
 
 #[derive(Error, Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum RequestError {
     #[error("The provided Uri was invalid")]
     InvalidUri,
@@ -10,6 +11,7 @@ pub enum RequestError {
 }
 
 #[derive(Error, Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum TokenDataError {
     #[error("No JWKs provided to decode token")]
     NoJWKs,

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -118,10 +118,10 @@ where
     serializer.append_pair("code", auth_code);
 
     if let Some(cs) = client_secret {
-        serializer.append_pair("client_secret", &cs);
+        serializer.append_pair("client_secret", cs);
     }
     if let Some(cv) = code_verifier {
-        serializer.append_pair("code_verifier", &cv);
+        serializer.append_pair("code_verifier", cv);
     }
 
     let body = serializer.finish();

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -57,18 +57,18 @@ impl Token {
     }
 }
 
-impl Into<Token> for TokenExchangeResponse {
-    fn into(self) -> Token {
-        let expires_ts = chrono::Utc::now().timestamp() + self.expires_in;
+impl From<TokenExchangeResponse> for Token {
+    fn from(t: TokenExchangeResponse) -> Token {
+        let expires_ts = chrono::Utc::now().timestamp() + t.expires_in;
 
         Token {
-            access_token: self.access_token,
-            token_type: self.token_type,
-            refresh_token: self.refresh_token,
-            expires_in: self.expires_in,
+            access_token: t.access_token,
+            token_type: t.token_type,
+            refresh_token: t.refresh_token,
+            expires_in: t.expires_in,
             expires_in_timestamp: expires_ts,
-            scope: self.scope,
-            id_token: self.id_token,
+            scope: t.scope,
+            id_token: t.id_token,
         }
     }
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -4,26 +4,9 @@ use std::convert::TryInto;
 use tame_oauth::Error;
 use url::form_urlencoded::Serializer;
 
-/// Request object sent in a token exchange request
-#[derive(serde::Deserialize, serde::Serialize, Debug)]
-pub struct TokenExchangeRequest {
-    /// Where to `POST` this request
-    pub uri: String,
-    /// Must be the same `redirect_uri` you used in the initial request
-    pub redirect_uri: String,
-    /// Identifies your application with the auth server
-    pub client_id: String,
-    /// The secret you don't share with anyone except the auth server
-    pub client_secret: Option<String>,
-    /// PKCE flow requires a code_verified to be present
-    pub code_verifier: Option<String>,
-    /// The auth_code you want to exchange for token(s)
-    pub auth_code: String,
-}
-
 /// This is the schema of the server's response.
 #[derive(serde::Deserialize, Debug)]
-pub struct TokenExchangeResponse {
+struct TokenExchangeResponse {
     /// The actual token
     access_token: String,
     /// The token type - most often `bearer`
@@ -128,14 +111,6 @@ where
     http_post_req(body, uri)
 }
 
-/// Construct a token exchange request object
-/// For [PKCE flow](https://tools.ietf.org/html/rfc7636#section-4.1) pass in the `code_verifier`
-/// and omit the `client_secret`.
-///
-/// For [authorization code flow](https://auth0.com/docs/flows/authorization-code-flow) pass in
-/// `client_secret` and omit `code_verifier`.
-///
-
 pub(crate) fn into_uri<U: TryInto<Uri>>(uri: U) -> Result<Uri, RequestError> {
     uri.try_into().map_err(|_err| RequestError::InvalidUri)
 }
@@ -208,7 +183,7 @@ mod test {
         )
         .unwrap();
 
-        let body = str::from_utf8(&request.body()).unwrap();
+        let body = str::from_utf8(request.body()).unwrap();
 
         // should not have client_secret parameter
         assert_eq!(body.contains("client_secret"), false);

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -39,8 +39,9 @@ impl Provider {
         &self,
         redirect_uri: RedirectUri,
         client_id: &str,
-        client_secret: &str,
         auth_code: &str,
+        client_secret: Option<&str>,
+        code_verifier: Option<&str>,
     ) -> Result<Request<Vec<u8>>, RequestError>
     where
         RedirectUri: TryInto<Uri>,
@@ -49,8 +50,9 @@ impl Provider {
             &self.token_endpoint,
             redirect_uri,
             client_id,
-            client_secret,
             auth_code,
+            client_secret,
+            code_verifier,
         )
     }
 

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -76,6 +76,7 @@ impl Provider {
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct JWK {
     kty: String,
     alg: String,
@@ -89,10 +90,12 @@ pub struct JWK {
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
+#[allow(clippy::upper_case_acronyms)]
 pub struct JWKS {
     pub keys: Vec<JWK>,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 impl JWKS {
     pub fn from_response<S>(response: http::Response<S>) -> Result<Self, tame_oauth::Error>
     where


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Adds the option to pass in a `code_verifier` to `exchange_token_request`.

Turned `client_secret` and `code_verifier` into `Option<&str>` to avoid having separate functions just for varying arguments.

Think this is the simplest approach we need at the moment. Can of course refactor into something more generic in the future if required.

This sadly breaks the current API and clients not using `PKCE` will have to change their `client_secret` to `Some(client_secret)` and pass in `None` for the `code_verifier`. Will thus require a version bump.

```
exchange_token_request(
  &url,
  &redirect_uri,
  &client_id,
  &auth_token,
  Some(&client_secret),
  None,
)?;
```
