### PR TITLE
Implement a strict certifiable OIDC flow

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ name = "embark"
 path = "examples/embark.rs"
 
 [dependencies]
+base64 = "0.13.0"
 chrono = "0.4"
 http = "0.2"
 jsonwebtoken = "7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,21 +21,21 @@ path = "examples/embark.rs"
 base64 = "0.13.0"
 chrono = "0.4"
 http = "0.2"
-jsonwebtoken = "7.2"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-url = "2.2"
-thiserror = "1"
+jsonwebtoken = "8.0.1"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.78"
+url = "2.2.2"
+thiserror = "1.0.30"
 
 ## dev dependencies below
 [dev-dependencies]
-bytes = "1.0"
+bytes = "1.1"
 
 [dev-dependencies.reqwest]
-version = "0.11"
+version = "0.11.9"
 features = ["rustls-tls"]
 default-features = false
 
 [dev-dependencies.tokio]
-version = "1.0"
+version = "1.16.1"
 features = ["macros", "rt-multi-thread"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ A very tame `OIDC` client based on `tame-oauth`.
 [![dependency status](https://deps.rs/repo/github/EmbarkStudios/tame-oidc/status.svg)](https://deps.rs/repo/github/EmbarkStudios/tame-oidc)
 [![Build status](https://github.com/gleam-lang/gleam/workflows/ci/badge.svg?branch=main)](https://github.com/EmbarkStudios/tame-oidc/actions)
 
-`tame-oidc` is a small oidc crate that follows the [sans-io](https://sans-io.readthedocs.io/) approach.
+`tame-oidc` is a small oidc crate that follows the [sans-io](https://sans-io.readthedocs.io/) approach.  
+It supports RFCs:
+- [RFC7636 Proof Key for Code Exchange by OAuth Public Clients](https://datatracker.ietf.org/doc/html/rfc7636#page-3)
+- 
 
 ## Why?
 

--- a/examples/oidc.rs
+++ b/examples/oidc.rs
@@ -1,0 +1,80 @@
+use bytes::Bytes;
+use http::Request;
+use std::{
+    convert::TryInto,
+    io::{prelude::*, stdin, stdout},
+};
+use tame_oidc::auth_scheme::{AuthenticationScheme, ClientAuthentication, ClientCredentials};
+use tame_oidc::strict::{ClientInfoStage, Finalized};
+
+/// Return reqwest response
+async fn http_send<Body: Into<reqwest::Body>>(
+    http_client: &reqwest::Client,
+    request: Request<Body>,
+) -> http::Response<Bytes> {
+    // Make the request
+    let mut response = http_client
+        .execute(request.try_into().unwrap())
+        .await
+        .unwrap();
+    // Convert to http::Response
+    let mut builder = http::Response::builder()
+        .status(response.status())
+        .version(response.version());
+    std::mem::swap(builder.headers_mut().unwrap(), response.headers_mut());
+    builder.body(response.bytes().await.unwrap()).unwrap()
+}
+
+async fn get_auth_code_input(state: Option<String>) -> (String, Option<String>) {
+    let mut s = String::new();
+    println!("Please enter authorization token:");
+    let _ = stdout().flush();
+    stdin()
+        .read_line(&mut s)
+        .expect("Could not read token from stdin");
+    s.pop();
+    (s, state)
+}
+
+/// Example user info struct to deserialize user_info into
+#[derive(serde::Deserialize, Debug)]
+#[allow(dead_code)]
+struct UserInfo {
+    sub: String,
+    email: String,
+    email_verified: bool,
+    phone_number: String,
+    phone_number_verified: bool,
+}
+
+#[tokio::main]
+async fn main() {
+    let http_client = reqwest::Client::new();
+
+    let issuer_domain = "https://www.certification.openid.net/...".to_owned(); // TODO: Oidc generated
+    let client_id = "my_client".to_owned();
+    let client_secret = "abc123".to_owned();
+    let redirect_uri = ""; // TODO: Add correct endpoint
+    let state = "dummy".to_owned();
+    let client_info_stage = ClientInfoStage::new(
+        issuer_domain,
+        ClientAuthentication::new(
+            client_id,
+            AuthenticationScheme::Basic(ClientCredentials::new(client_secret)),
+            None,
+            Some(state.clone()),
+        ),
+        redirect_uri.to_owned(),
+        Some(vec![
+            "openid".to_owned(),
+            "profile".to_owned(),
+            "email".to_owned(),
+            "phone".to_owned(),
+            "address".to_owned(),
+        ]),
+    );
+    let send = |req: Request<Vec<u8>>| http_send(&http_client, req);
+    let code = get_auth_code_input(Some(state));
+    let finalized: Finalized<UserInfo> = client_info_stage.run_to_end(send, code).await.unwrap();
+    println!("{:?}", finalized);
+}

--- a/src/auth_scheme.rs
+++ b/src/auth_scheme.rs
@@ -1,0 +1,61 @@
+#[derive(Debug)]
+pub struct ClientAuthentication {
+    pub client_id: String,
+    pub scheme: AuthenticationScheme,
+    pub nonce: Option<String>,
+    pub state: Option<String>,
+}
+
+impl ClientAuthentication {
+    pub fn new(
+        client_id: String,
+        scheme: AuthenticationScheme,
+        nonce: Option<String>,
+        state: Option<String>,
+    ) -> Self {
+        ClientAuthentication {
+            client_id,
+            scheme,
+            nonce,
+            state,
+        }
+    }
+}
+#[derive(Debug)]
+pub enum AuthenticationScheme {
+    Basic(ClientCredentials),
+    Post(ClientCredentials),
+    Pkce(PkceCredentials),
+}
+
+#[derive(Debug)]
+pub struct ClientCredentials {
+    pub client_secret: String,
+}
+
+impl ClientCredentials {
+    pub fn new(client_secret: String) -> Self {
+        ClientCredentials { client_secret }
+    }
+}
+
+#[derive(Debug)]
+pub struct PkceCredentials {
+    pub code_challenge: String,
+    pub code_challenge_method: String,
+    pub code_verifier: String,
+}
+
+impl PkceCredentials {
+    pub fn new(
+        code_challenge: String,
+        code_challenge_method: String,
+        code_verifier: String,
+    ) -> Self {
+        PkceCredentials {
+            code_challenge,
+            code_challenge_method,
+            code_verifier,
+        }
+    }
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -19,6 +19,25 @@ pub enum TokenDataError {
 }
 
 #[derive(thiserror::Error, Debug)]
+#[allow(clippy::upper_case_acronyms)]
+pub enum OidcValidationError {
+    #[error("Nonce doesn't match initially provided nonce")]
+    NonceMismatch,
+
+    #[error("Sub from user data doesn't match sub from token data")]
+    UserMismatch,
+
+    #[error("Could not decode user info as utf8")]
+    UserInfoDecode,
+
+    #[error("Could not deserialize user info")]
+    UserinfoDeserialize,
+
+    #[error("State doesn't match initially provided state")]
+    StateMismatch,
+}
+
+#[derive(thiserror::Error, Debug)]
 pub enum Error {
     /// Failed to authenticate and retrieve an oauth token, and were unable to
     /// deserialize a more exact reason from the error response
@@ -30,4 +49,14 @@ pub enum Error {
     /// An error occurred trying to create an HTTP request
     #[error(transparent)]
     Http(#[from] http::Error),
+
+    #[error(transparent)]
+    Request(#[from] RequestError),
+
+    #[error(transparent)]
+    TokenValidation(#[from] TokenDataError),
+
+    #[error(transparent)]
+    // Todo: Better name
+    OidcValidation(#[from] OidcValidationError),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,4 +74,6 @@ pub mod errors;
 pub mod oidc;
 pub mod provider;
 
+pub mod auth_scheme;
 mod deserialize_uri;
+pub mod strict;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,6 @@
 )]
 // END - Embark standard lints v0.4
 // crate-specific exceptions:
-#![allow()]
 
 pub mod errors;
 pub mod oidc;

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -27,8 +27,7 @@ where
         "scope",
         &scopes
             .as_ref()
-            .map(|s| s.join(" "))
-            .unwrap_or_else(|| "openid".to_owned()),
+            .map_or_else(|| "openid".to_owned(), |s| s.join(" ")),
     );
     if let Some(state) = &auth.state {
         serializer.append_pair("state", state);
@@ -276,7 +275,7 @@ mod test {
             AuthenticationScheme::Pkce(PkceCredentials::new(
                 "ch".to_owned(),
                 "&S256".to_owned(),
-                spooky_secret_verifier.clone(),
+                spooky_secret_verifier,
             )),
             None,
             None,
@@ -293,6 +292,6 @@ mod test {
 
         // should not have client_secret parameter
         assert!(!body.contains("client_secret"));
-        assert!(body.contains("code_verifier"))
+        assert!(body.contains("code_verifier"));
     }
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,7 +1,67 @@
+use crate::auth_scheme::{AuthenticationScheme, ClientAuthentication};
 use crate::errors::{Error, RequestError};
+use http::header::AUTHORIZATION;
 use http::{header::CONTENT_TYPE, Request, Uri};
 use std::convert::TryInto;
 use url::form_urlencoded::Serializer;
+
+pub fn authorization_request<ReqUri, RedirectUri>(
+    uri: ReqUri,
+    redirect_uri: RedirectUri,
+    auth: &ClientAuthentication,
+    scopes: &Option<Vec<String>>,
+) -> Result<Request<Vec<u8>>, RequestError>
+where
+    ReqUri: TryInto<Uri>,
+    RedirectUri: TryInto<Uri>,
+{
+    let request_builder = Request::builder()
+        .method("POST")
+        .uri(into_uri(uri)?)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded");
+    let mut serializer = Serializer::new(String::new());
+    serializer.append_pair("redirect_uri", &into_uri(redirect_uri)?.to_string());
+    serializer.append_pair("grant_type", "authorization_code");
+    serializer.append_pair("response_type", "code");
+    serializer.append_pair(
+        "scope",
+        &scopes
+            .as_ref()
+            .map(|s| s.join(" "))
+            .unwrap_or_else(|| "openid".to_owned()),
+    );
+    if let Some(state) = &auth.state {
+        serializer.append_pair("state", state);
+    }
+    if let Some(nonce) = &auth.nonce {
+        serializer.append_pair("nonce", nonce);
+    }
+    serializer.append_pair("client_id", &auth.client_id);
+
+    let body = match &auth.scheme {
+        AuthenticationScheme::Basic(client_credentials) => {
+            let basic = base64::encode(format!(
+                "{}:{}",
+                &auth.client_id, client_credentials.client_secret
+            ));
+            request_builder
+                .header(AUTHORIZATION, format!("Basic {}", basic))
+                .body(Vec::from(serializer.finish()))
+        }
+        AuthenticationScheme::Post(client_credentials) => request_builder.body(Vec::from(
+            serializer
+                .append_pair("client_secret", &client_credentials.client_secret)
+                .finish(),
+        )),
+        AuthenticationScheme::Pkce(pkce) => request_builder.body(Vec::from(
+            serializer
+                .append_pair("code_challenge", &pkce.code_challenge)
+                .append_pair("code_challenge_method", &pkce.code_challenge_method)
+                .finish(),
+        )),
+    }?;
+    Ok(body)
+}
 
 /// This is the schema of the server's response.
 #[derive(serde::Deserialize, Debug)]
@@ -11,7 +71,7 @@ struct TokenExchangeResponse {
     /// The token type - most often `bearer`
     token_type: String,
     /// The time until the token expires and a new one needs to be requested
-    expires_in: i64,
+    expires_in: Option<i64>,
     /// The scope used for this token - most often `openid`
     scope: String,
     /// A JSON Web Token that contains information about an authentication event
@@ -30,9 +90,9 @@ pub struct Token {
     /// The token type - most often `bearer`
     pub token_type: String,
     /// The time until the token expires and a new one needs to be requested
-    pub expires_in: i64,
+    pub expires_in: Option<i64>,
     /// The time until the token expires and a new one needs to be requested
-    pub expires_in_timestamp: i64,
+    pub expires_in_timestamp: Option<i64>,
     /// The scope used for this token - most often `openid`
     pub scope: String,
     /// A JSON Web Token that contains information about an authentication event
@@ -58,7 +118,9 @@ impl Token {
 
 impl From<TokenExchangeResponse> for Token {
     fn from(t: TokenExchangeResponse) -> Token {
-        let expires_ts = chrono::Utc::now().timestamp() + t.expires_in;
+        let expires_ts = t
+            .expires_in
+            .map(|time_until| time_until + chrono::Utc::now().timestamp());
 
         Token {
             access_token: t.access_token,
@@ -84,34 +146,60 @@ impl From<TokenExchangeResponse> for Token {
 pub fn exchange_token_request<ReqUri, RedirectUri>(
     uri: ReqUri,
     redirect_uri: RedirectUri,
-    client_id: &str,
+    auth: &ClientAuthentication,
     auth_code: &str,
-    client_secret: Option<&str>,
-    code_verifier: Option<&str>,
 ) -> Result<Request<Vec<u8>>, RequestError>
 where
     ReqUri: TryInto<Uri>,
     RedirectUri: TryInto<Uri>,
 {
     let mut serializer = Serializer::new(String::new());
-    serializer.append_pair("client_id", client_id);
     serializer.append_pair("redirect_uri", &into_uri(redirect_uri)?.to_string());
     serializer.append_pair("grant_type", "authorization_code");
     serializer.append_pair("code", auth_code);
-
-    if let Some(cs) = client_secret {
-        serializer.append_pair("client_secret", cs);
-    }
-    if let Some(cv) = code_verifier {
-        serializer.append_pair("code_verifier", cv);
-    }
-
-    let body = serializer.finish();
-    http_post_req(body, uri)
+    let request_builder = Request::builder()
+        .method("POST")
+        .uri(into_uri(uri)?)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded");
+    serializer.append_pair("client_id", &auth.client_id);
+    let body = match &auth.scheme {
+        AuthenticationScheme::Basic(client_credentials) => {
+            let basic = base64::encode(format!(
+                "{}:{}",
+                &auth.client_id, client_credentials.client_secret
+            ));
+            request_builder
+                .header(AUTHORIZATION, format!("Basic {}", basic))
+                .body(Vec::from(serializer.finish()))
+        }
+        AuthenticationScheme::Post(client_credentials) => request_builder.body(Vec::from(
+            serializer
+                .append_pair("client_secret", &client_credentials.client_secret)
+                .finish(),
+        )),
+        AuthenticationScheme::Pkce(pkce) => request_builder.body(Vec::from(
+            serializer
+                .append_pair("code_verifier", &pkce.code_verifier)
+                .finish(),
+        )),
+    }?;
+    Ok(body)
 }
 
 pub(crate) fn into_uri<U: TryInto<Uri>>(uri: U) -> Result<Uri, RequestError> {
     uri.try_into().map_err(|_err| RequestError::InvalidUri)
+}
+
+pub(crate) fn user_info_request<ReqUri>(
+    uri: ReqUri,
+    access_token: &str,
+) -> Result<Request<Vec<u8>>, RequestError>
+where
+    ReqUri: TryInto<Uri>,
+{
+    Ok(Request::get(into_uri(uri)?)
+        .header(AUTHORIZATION, format!("Bearer {}", access_token))
+        .body(vec![])?)
 }
 
 /// Once a response has been received for a token request, call this
@@ -136,49 +224,68 @@ where
 
 pub fn refresh_token_request<ReqUri>(
     uri: ReqUri,
-    client_id: &str,
-    client_secret: &str,
+    auth: &ClientAuthentication,
     refresh_token: &str,
 ) -> Result<Request<Vec<u8>>, RequestError>
 where
     ReqUri: TryInto<Uri>,
 {
-    let body = Serializer::new(String::new())
-        .append_pair("client_id", client_id)
-        .append_pair("client_secret", client_secret)
-        .append_pair("grant_type", "refresh_token")
-        .append_pair("refresh_token", refresh_token)
-        .finish();
-
-    http_post_req(body, uri)
-}
-
-fn http_post_req<ReqUri>(body: String, uri: ReqUri) -> Result<Request<Vec<u8>>, RequestError>
-where
-    ReqUri: TryInto<Uri>,
-{
-    let req_body = Vec::from(body);
-    Ok(Request::builder()
+    let mut partial = Serializer::new(String::new());
+    partial.append_pair("grant_type", "refresh_token");
+    partial.append_pair("refresh_token", refresh_token);
+    let request_builder = Request::builder()
         .method("POST")
         .uri(into_uri(uri)?)
-        .header(CONTENT_TYPE, "application/x-www-form-urlencoded")
-        .body(req_body)?)
+        .header(CONTENT_TYPE, "application/x-www-form-urlencoded");
+    partial.append_pair("client_id", &auth.client_id);
+    let body = match &auth.scheme {
+        AuthenticationScheme::Basic(client_credentials) => {
+            let basic = base64::encode(format!(
+                "{}:{}",
+                &auth.client_id, client_credentials.client_secret
+            ));
+            request_builder
+                .header(AUTHORIZATION, format!("Basic {}", basic))
+                .body(Vec::from(partial.finish()))
+        }
+        AuthenticationScheme::Post(client_credentials) => request_builder.body(Vec::from(
+            partial
+                .append_pair("client_secret", &client_credentials.client_secret)
+                .finish(),
+        )),
+        AuthenticationScheme::Pkce(pkce) => request_builder.body(Vec::from(
+            partial
+                .append_pair("code_verifier", &pkce.code_verifier)
+                .finish(),
+        )),
+    }?;
+    Ok(body)
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::auth_scheme::PkceCredentials;
     use std::str;
 
     #[test]
     fn pkce_flow_exchange() {
+        let spooky_secret_verifier = "the_secret_verifier".to_owned();
+        let client_credentials = ClientAuthentication::new(
+            "client_id".to_owned(),
+            AuthenticationScheme::Pkce(PkceCredentials::new(
+                "ch".to_owned(),
+                "&S256".to_owned(),
+                spooky_secret_verifier.clone(),
+            )),
+            None,
+            None,
+        );
         let request = exchange_token_request(
             "https://www.example.com/",
             "http://localhost:8000/",
-            "client_id",
+            &client_credentials,
             "auth-code",
-            None,
-            Some("the_secret_code_verifier"),
         )
         .unwrap();
 
@@ -186,8 +293,6 @@ mod test {
 
         // should not have client_secret parameter
         assert!(!body.contains("client_secret"));
-
-        // should have code_verifier parameter
-        assert!(body.contains("code_verifier=the_secret_code_verifier"));
+        assert!(body.contains("code_verifier"))
     }
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -87,11 +87,7 @@ impl Provider {
         Err(TokenDataError::NoJWKs)
     }
 
-    pub fn validate_token_signature(
-        &self,
-        token: &Token,
-        jwks: &[JWK],
-    ) -> Result<(), TokenDataError> {
+    pub fn validate_token_signature(token: &Token, jwks: &[JWK]) -> Result<(), TokenDataError> {
         if let Some(ref id_token) = token.id_token {
             let validation = Validation {
                 algorithms: vec![Algorithm::RS256, Algorithm::RS384, Algorithm::RS512],

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -227,8 +227,10 @@ fn try_token_data(
     token: &str,
     enc_key: &RsaJwk,
 ) -> jsonwebtoken::errors::Result<TokenData<Claims>> {
-    let mut validation = Validation::default();
-    validation.algorithms = vec![Algorithm::RS256, Algorithm::RS384, Algorithm::RS512];
+    let validation = Validation {
+        algorithms: vec![Algorithm::RS256, Algorithm::RS384, Algorithm::RS512],
+        ..Default::default()
+    };
 
     decode::<Claims>(
         token,
@@ -266,7 +268,7 @@ fn try_token_rsa_data(
     decode::<Claims>(
         token,
         &DecodingKey::from_rsa_components(key, exponent),
-        &validation,
+        validation,
     )
 }
 /// Return a Request object for validating a well-known OIDC issuer

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -162,13 +162,18 @@ impl TokenValidationStage {
         let token_data = self
             .provider
             .validate_token_data(&self.client_data.auth.client_id, &self.token)?;
+
         if token_data.claims.nonce != self.client_data.auth.nonce {
             return Err(crate::errors::Error::OidcValidation(
                 OidcValidationError::NonceMismatch,
             ));
         }
+        self.provider.validate_token_signature(
+            &self.client_data.auth.client_id,
+            &self.token,
+            jwks.keys.as_slice(),
+        )?;
         let sub = token_data.claims.sub.clone();
-        Provider::validate_token_signature(&self.token, jwks.keys.as_slice())?;
         Ok(UserInfoStage {
             client_data: self.client_data,
             provider: self.provider,

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -63,8 +63,7 @@ impl ClientInfoStage {
         let authorization = self.validate_provider(res)?;
         let _res = (req_fn)(authorization.generate_authorization_request()?).await;
         let (auth_code, state) = auth_fut.await;
-        let token =
-            authorization.validate_auth_info(auth_code, state.as_ref().map(|s| s.as_str()))?;
+        let token = authorization.validate_auth_info(auth_code, state.as_deref())?;
         let res = (req_fn)(token.generate_access_token_request()?).await;
         let validate = token.parse_token(res)?;
         let res = (req_fn)(validate.generate_provider_jwks_request()?).await;
@@ -97,7 +96,7 @@ impl AuthorizationStage {
         auth_code: String,
         state: Option<&str>,
     ) -> Result<AccessTokenStage, Error> {
-        if state != self.client_data.auth.state.as_ref().map(|s| s.as_str()) {
+        if state != self.client_data.auth.state.as_deref() {
             return Err(crate::errors::Error::OidcValidation(
                 OidcValidationError::UserMismatch,
             ));

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -1,0 +1,238 @@
+use crate::auth_scheme::ClientAuthentication;
+use crate::errors::{Error, OidcValidationError, TokenDataError};
+use crate::oidc::Token;
+use crate::provider;
+use crate::provider::{Claims, Provider, JWKS};
+use http::{Request, Response};
+use jsonwebtoken::TokenData;
+use serde::de::DeserializeOwned;
+use std::future::Future;
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ClientInfoStage {
+    pub issuer_domain: String,
+    pub auth: ClientAuthentication,
+    pub redirect_uri: String,
+    pub scopes: Option<Vec<String>>,
+}
+
+impl ClientInfoStage {
+    pub fn new(
+        issuer_domain: String,
+        auth: ClientAuthentication,
+        redirect_uri: String,
+        scopes: Option<Vec<String>>,
+    ) -> Self {
+        ClientInfoStage {
+            issuer_domain,
+            auth,
+            redirect_uri,
+            scopes,
+        }
+    }
+
+    pub fn generate_provider_request(&self) -> Result<Request<Vec<u8>>, Error> {
+        provider::well_known(&self.issuer_domain)
+    }
+
+    pub fn validate_provider<S>(self, input: Response<S>) -> Result<AuthorizationStage, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let provider = Provider::from_response(input)?;
+        Ok(AuthorizationStage {
+            client_data: self,
+            provider,
+        })
+    }
+
+    pub async fn run_to_end<'a, ReqFn, ReqFut, S, AuthFut, U>(
+        self,
+        req_fn: ReqFn,
+        auth_fut: AuthFut,
+    ) -> Result<Finalized<U>, Error>
+    where
+        ReqFn: Fn(Request<Vec<u8>>) -> ReqFut,
+        ReqFut: Future<Output = Response<S>>,
+        S: AsRef<[u8]>,
+        AuthFut: Future<Output = (String, Option<String>)>,
+        U: DeserializeOwned,
+    {
+        let res = (req_fn)(self.generate_provider_request()?).await;
+        let authorization = self.validate_provider(res)?;
+        let _res = (req_fn)(authorization.generate_authorization_request()?).await;
+        let (auth_code, state) = auth_fut.await;
+        let token =
+            authorization.validate_auth_info(auth_code, state.as_ref().map(|s| s.as_str()))?;
+        let res = (req_fn)(token.generate_access_token_request()?).await;
+        let validate = token.parse_token(res)?;
+        let res = (req_fn)(validate.generate_provider_jwks_request()?).await;
+        let fetch_user_info = validate.validate_token(res)?;
+        let res = (req_fn)(fetch_user_info.generate_fetch_request()?).await;
+        fetch_user_info.finalize(res)
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct AuthorizationStage {
+    pub client_data: ClientInfoStage,
+    pub provider: Provider,
+}
+
+impl AuthorizationStage {
+    pub fn generate_authorization_request(&self) -> Result<Request<Vec<u8>>, Error> {
+        self.provider
+            .authorization_request(
+                &self.client_data.redirect_uri,
+                &self.client_data.auth,
+                &self.client_data.scopes,
+            )
+            .map_err(|e| e.into())
+    }
+
+    pub fn validate_auth_info(
+        self,
+        auth_code: String,
+        state: Option<&str>,
+    ) -> Result<AccessTokenStage, Error> {
+        if state != self.client_data.auth.state.as_ref().map(|s| s.as_str()) {
+            return Err(crate::errors::Error::OidcValidation(
+                OidcValidationError::UserMismatch,
+            ));
+        }
+        Ok(AccessTokenStage {
+            client_data: self.client_data,
+            provider: self.provider,
+            auth_code,
+        })
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct AccessTokenStage {
+    pub client_data: ClientInfoStage,
+    pub provider: Provider,
+    pub auth_code: String,
+}
+
+impl AccessTokenStage {
+    pub fn generate_access_token_request(&self) -> Result<Request<Vec<u8>>, Error> {
+        self.provider
+            .exchange_token_request(
+                &self.client_data.redirect_uri,
+                &self.client_data.auth,
+                &self.auth_code,
+            )
+            .map_err(|e| e.into())
+    }
+
+    pub fn parse_token<S>(self, input: Response<S>) -> Result<TokenValidationStage, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let token = Token::from_response(input)?;
+        Ok(TokenValidationStage {
+            client_data: self.client_data,
+            provider: self.provider,
+            token,
+        })
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct TokenValidationStage {
+    pub client_data: ClientInfoStage,
+    pub provider: Provider,
+    pub token: Token,
+}
+
+impl TokenValidationStage {
+    pub fn generate_provider_jwks_request(&self) -> Result<Request<Vec<u8>>, Error> {
+        self.provider.jwks_request().map_err(|e| e.into())
+    }
+
+    pub fn validate_token<S>(self, input: Response<S>) -> Result<UserInfoStage, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let jwks = JWKS::from_response(input)?;
+        let token_data = self
+            .provider
+            .validate_token_data(&self.client_data.auth.client_id, &self.token)?;
+        if token_data.claims.nonce != self.client_data.auth.nonce {
+            return Err(crate::errors::Error::OidcValidation(
+                OidcValidationError::NonceMismatch,
+            ));
+        }
+        let sub = token_data.claims.sub.clone();
+        self.provider
+            .validate_token_signature(&self.token, jwks.keys.as_slice())?;
+        Ok(UserInfoStage {
+            client_data: self.client_data,
+            provider: self.provider,
+            token: self.token,
+            token_data,
+            sub,
+        })
+    }
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct UserInfoStage {
+    pub client_data: ClientInfoStage,
+    pub provider: Provider,
+    pub token: Token,
+    pub token_data: TokenData<Claims>,
+    pub sub: String,
+}
+
+/// Only used to verify subject
+#[derive(Debug, serde::Deserialize)]
+struct UserInfo {
+    pub sub: String,
+}
+
+#[derive(Debug)]
+pub struct Finalized<U> {
+    pub client_data: ClientInfoStage,
+    pub provider: Provider,
+    pub token: Token,
+    pub token_data: TokenData<Claims>,
+    pub user_data: U,
+}
+
+impl UserInfoStage {
+    pub fn generate_fetch_request(&self) -> Result<Request<Vec<u8>>, Error> {
+        self.provider
+            .user_info_request(&self.token.access_token)
+            .map_err(|e| e.into())
+    }
+
+    pub fn finalize<S, U: DeserializeOwned>(self, input: Response<S>) -> Result<Finalized<U>, Error>
+    where
+        S: AsRef<[u8]>,
+    {
+        let result = input.body().as_ref();
+        let raw_user_data = String::from_utf8(result.to_vec())
+            .map_err(|_e| Error::OidcValidation(OidcValidationError::UserInfoDecode))?;
+        let user_info = serde_json::from_str::<UserInfo>(&raw_user_data)
+            .map_err(|_e| Error::OidcValidation(OidcValidationError::UserinfoDeserialize))?;
+        if user_info.sub != self.sub {
+            Err(Error::OidcValidation(OidcValidationError::UserMismatch))
+        } else {
+            let user_data = serde_json::from_slice(raw_user_data.as_bytes())?;
+            Ok(Finalized {
+                client_data: self.client_data,
+                provider: self.provider,
+                token: self.token,
+                token_data: self.token_data,
+                user_data,
+            })
+        }
+    }
+}

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -168,8 +168,7 @@ impl TokenValidationStage {
             ));
         }
         let sub = token_data.claims.sub.clone();
-        self.provider
-            .validate_token_signature(&self.token, jwks.keys.as_slice())?;
+        Provider::validate_token_signature(&self.token, jwks.keys.as_slice())?;
         Ok(UserInfoStage {
             client_data: self.client_data,
             provider: self.provider,

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -1,5 +1,5 @@
 use crate::auth_scheme::ClientAuthentication;
-use crate::errors::{Error, OidcValidationError, TokenDataError};
+use crate::errors::{Error, OidcValidationError};
 use crate::oidc::Token;
 use crate::provider;
 use crate::provider::{Claims, Provider, JWKS};


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

This PR aims to make tame-oidc oidc-relying-party-certifiable which means passing some tests that OIDC has set up https://www.certification.openid.net/

To do this a strict flow was implemented which will ensure compliance if used, while the tools used by it can be used to construct your own possibly compliant flow, but without any guarantees. 

The oidc tests require implementation of basic auth, so that was added. Additionally some JWT verification methods were added. 

Some imperfect implementation details:

- We only try RSA JWKS
- We try all JWKS when trying to verify a signature in no particular order even though we (likely) have the key_id used to sign the token. Simplifies the case where a key_id is omitted, if the provider only provides one set of keys we're supposed to use that, if the provider specifies many it's up to us whether or not to try all or to throw an error, this implementation will try all.


Some improvements I'd like to make when there's more time

- Integration tests, spin up a bare-bones IDP with axum and unit-test so changes aren't so spooky
- Could put different auth methods behind feature gates if we don't want to pull in b64 if you don't use basic auth


### Related Issues

Pre-requisite for completing https://github.com/EmbarkStudios/tame-oidc/issues/14
