### PR TITLE
Replace chrono

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,13 +19,13 @@ path = "examples/embark.rs"
 
 [dependencies]
 base64 = "0.13.0"
-chrono = "0.4"
 http = "0.2"
 jsonwebtoken = "8.0.1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 url = "2.2.2"
 thiserror = "1.0.30"
+time = "0.3.7"
 
 ## dev dependencies below
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.78"
 url = "2.2.2"
 thiserror = "1.0.30"
-time = "0.3.7"
 
 ## dev dependencies below
 [dev-dependencies]

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,7 @@ confidence-threshold = 0.92
 allow = [
     "Apache-2.0",
     "MIT",
+    "BSD-3-Clause"
 ]
 exceptions = [
     { allow = ["MPL-2.0"], name = "webpki-roots" },
@@ -54,12 +55,9 @@ license-files = [
 ]
 
 [[licenses.clarify]]
-name = "encoding-rs"
-expression = "MIT AND Apache-2.0"
-license-files = [
-    { path = "LICENSE-MIT", hash = 0xafaec4cb },
-    { path = "LICENSE-APACHE", hash = 0x18785531 },
-]
+name = "encoding_rs"
+expression = "(Apache-2.0 OR MIT) AND BSD-3-Clause"
+license-files = [{ path = "COPYRIGHT", hash = 0x39f8ad31 }]
 
 [[licenses.clarify]]
 name = "webpki"

--- a/deny.toml
+++ b/deny.toml
@@ -17,8 +17,7 @@ deny = [
     { name = "openssl-sys" },
 ]
 skip = [
-    # most crates still reference the pre 1.0 version
-    { name = "base64", version = "0.12.3" },
+    { name = "itoa", version = "=0.4.8"},
 ]
 skip-tree = [
 ]
@@ -52,6 +51,14 @@ name = "ring"
 expression = "ISC AND MIT AND OpenSSL"
 license-files = [
     { path = "LICENSE", hash = 0xbd0eed23 },
+]
+
+[[licenses.clarify]]
+name = "encoding-rs"
+expression = "MIT AND Apache-2.0"
+license-files = [
+    { path = "LICENSE-MIT", hash = 0xafaec4cb },
+    { path = "LICENSE-APACHE", hash = 0x18785531 },
 ]
 
 [[licenses.clarify]]

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -120,9 +120,9 @@ impl From<TokenExchangeResponse> for Token {
     fn from(t: TokenExchangeResponse) -> Token {
         let expires_ts = t.expires_in.and_then(|time_until| {
             SystemTime::now()
-                .duration_since(UNIX_EPOCH)
+                .duration_since(UNIX_EPOCH) // Only an err if time moved backwards
                 .ok()
-                .and_then(|time_stamp| time_stamp.as_secs().try_into().ok())
+                .and_then(|time_stamp| time_stamp.as_secs().try_into().ok()) // Only an err after year 2264
                 .map(|now_as_seconds: i64| time_until + now_as_seconds)
         });
 

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -119,7 +119,7 @@ impl From<TokenExchangeResponse> for Token {
     fn from(t: TokenExchangeResponse) -> Token {
         let expires_ts = t
             .expires_in
-            .map(|time_until| time_until + chrono::Utc::now().timestamp());
+            .map(|time_until| time_until + time::OffsetDateTime::now_utc().unix_timestamp());
 
         Token {
             access_token: t.access_token,

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -3,6 +3,7 @@ use crate::errors::{Error, RequestError};
 use http::header::AUTHORIZATION;
 use http::{header::CONTENT_TYPE, Request, Uri};
 use std::convert::TryInto;
+use std::time::{SystemTime, UNIX_EPOCH};
 use url::form_urlencoded::Serializer;
 
 pub fn authorization_request<ReqUri, RedirectUri>(
@@ -117,9 +118,13 @@ impl Token {
 
 impl From<TokenExchangeResponse> for Token {
     fn from(t: TokenExchangeResponse) -> Token {
-        let expires_ts = t
-            .expires_in
-            .map(|time_until| time_until + time::OffsetDateTime::now_utc().unix_timestamp());
+        let expires_ts = t.expires_in.and_then(|time_until| {
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .ok()
+                .and_then(|time_stamp| time_stamp.as_secs().try_into().ok())
+                .map(|now_as_seconds: i64| time_until + now_as_seconds)
+        });
 
         Token {
             access_token: t.access_token,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Replace chrono with std::time equivalent time checking

Added some comments on the option unpacking, chose to just map errs to None, but considering that it would only err on the conditions that either: 
- Systemtime shows a time before the UNIX_EPOCH
- Systemtime shows a time after year 2264
Then maybe we should just unwrap it, as an off systemtime is incompatible with most authentication schemes that contain time-scoped tokens and discovering that quickly may be preferable.

Closes https://github.com/EmbarkStudios/tame-oidc/issues/16
