### PR TITLE
Pkce can have an optional client_secret

### DIFF
--- a/src/auth_scheme.rs
+++ b/src/auth_scheme.rs
@@ -44,6 +44,7 @@ pub struct PkceCredentials {
     pub code_challenge: String,
     pub code_challenge_method: String,
     pub code_verifier: String,
+    pub client_secret: Option<String>,
 }
 
 impl PkceCredentials {
@@ -51,11 +52,13 @@ impl PkceCredentials {
         code_challenge: String,
         code_challenge_method: String,
         code_verifier: String,
+        client_secret: Option<String>,
     ) -> Self {
         PkceCredentials {
             code_challenge,
             code_challenge_method,
             code_verifier,
+            client_secret,
         }
     }
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -181,11 +181,16 @@ where
                 .append_pair("client_secret", &client_credentials.client_secret)
                 .finish(),
         )),
-        AuthenticationScheme::Pkce(pkce) => request_builder.body(Vec::from(
-            serializer
-                .append_pair("code_verifier", &pkce.code_verifier)
-                .finish(),
-        )),
+        AuthenticationScheme::Pkce(pkce) => {
+            if let Some(client_secret) = &pkce.client_secret {
+                serializer.append_pair("client_secret", client_secret);
+            }
+            request_builder.body(Vec::from(
+                serializer
+                    .append_pair("code_verifier", &pkce.code_verifier)
+                    .finish(),
+            ))
+        }
     }?;
     Ok(body)
 }
@@ -281,6 +286,7 @@ mod test {
                 "ch".to_owned(),
                 "&S256".to_owned(),
                 spooky_secret_verifier,
+                None,
             )),
             None,
             None,


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes
Allow client_secret optionally in the PKCE flow, semi hesistant to add this. Since sending a client_secret sort of defeats the purpose of PKCE as described in its RFC https://datatracker.ietf.org/doc/html/rfc7636, however the oauth docs says client_secret is optional so maybe it should be added, it's a small change https://www.oauth.com/oauth2-servers/pkce/authorization-code-exchange/

