### PR TITLE
Upgrade base64 crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- Make provider conform better to spec by making fields `token_endpoint` and `userinfo_endpoint` optional.
+
+## [0.6.0] - 
 ### Changed
 - Make claims flexible by accepting any user provided DeserializeOwned in functions, 
 that extract claims.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,9 @@ path = "examples/embark.rs"
 [dependencies]
 base64 = "0.21"
 http = "0.2"
-jsonwebtoken = "8.1"
+# While waiting for https://github.com/Keats/jsonwebtoken/pull/303 to get in we need
+# to rely on this forked commit for the `pem` crate to use `base64 0.21`
+jsonwebtoken = { git = "https://github.com/EmbarkStudios/jsonwebtoken", rev = "ccd4394b49c1b92590ba6cca0f5d1ec44c813acd" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2.3"
@@ -29,10 +31,10 @@ thiserror = "1"
 
 ## dev dependencies below
 [dev-dependencies]
-bytes = "1.2"
+bytes = "1.4"
 
 [dev-dependencies.reqwest]
-version = "0.11"
+version = "0.11.18"
 features = ["rustls-tls"]
 default-features = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ name = "embark"
 path = "examples/embark.rs"
 
 [dependencies]
-base64 = "0.13"
+base64 = "0.21"
 http = "0.2"
 jsonwebtoken = "8.1"
 serde = { version = "1", features = ["derive"] }
@@ -37,5 +37,5 @@ features = ["rustls-tls"]
 default-features = false
 
 [dev-dependencies.tokio]
-version = "1.21"
+version = "1.28"
 features = ["macros", "rt-multi-thread"]

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,11 @@ skip = [
 skip-tree = [
 ]
 
+[sources]
+allow-git = [
+    "https://github.com/EmbarkStudios/jsonwebtoken",
+]
+
 [licenses]
 unlicensed = "deny"
 # We want really high confidence when inferring licenses from text
@@ -34,6 +39,7 @@ exceptions = [
     { allow = ["MPL-2.0"], name = "webpki-roots" },
     { allow = ["ISC"], name = "untrusted" },
     { allow = ["ISC"], name = "webpki" },
+    { allow = ["ISC"], name = "rustls-webpki" },
     { allow = ["ISC"], name = "simple_asn1" },
     { allow = ["ISC", "MIT", "OpenSSL"], name = "ring" },
     { allow = ["Zlib"], name = "tinyvec" },
@@ -61,6 +67,13 @@ license-files = [{ path = "COPYRIGHT", hash = 0x39f8ad31 }]
 
 [[licenses.clarify]]
 name = "webpki"
+expression = "ISC"
+license-files = [
+    { path = "LICENSE", hash = 0x001c7e6c },
+]
+
+[[licenses.clarify]]
+name = "rustls-webpki"
 expression = "ISC"
 license-files = [
     { path = "LICENSE", hash = 0x001c7e6c },

--- a/src/deserialize_uri.rs
+++ b/src/deserialize_uri.rs
@@ -1,8 +1,9 @@
 use http::Uri;
+use serde::de::Error;
 use serde::{de, Deserializer};
 use std::fmt;
 
-struct UriVisitor;
+pub struct UriVisitor;
 impl<'de> de::Visitor<'de> for UriVisitor {
     type Value = Uri;
 
@@ -16,9 +17,44 @@ impl<'de> de::Visitor<'de> for UriVisitor {
     }
 }
 
+pub struct OptionalUriVisitor;
+impl<'de> de::Visitor<'de> for OptionalUriVisitor {
+    type Value = Option<Uri>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "valid uri")
+    }
+
+    #[inline]
+    fn visit_str<E: de::Error>(self, val: &str) -> Result<Self::Value, E> {
+        Some(UriVisitor.visit_str(val)).transpose()
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(None)
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Some(deserializer.deserialize_option(UriVisitor)).transpose()
+    }
+}
+
 pub fn deserialize<'de, D>(de: D) -> Result<Uri, D::Error>
 where
     D: Deserializer<'de>,
 {
     de.deserialize_str(UriVisitor)
+}
+
+pub fn deserialize_opt<'de, D>(de: D) -> Result<Option<Uri>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    de.deserialize_str(OptionalUriVisitor)
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -4,6 +4,9 @@ pub enum RequestError {
     #[error("The provided Uri was invalid")]
     InvalidUri,
 
+    #[error("Precondition unfulfilled: {0}")]
+    PreconditionUnfulfilled(String),
+
     #[error(transparent)]
     HTTP(#[from] http::Error),
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -7,8 +7,8 @@ use std::convert::TryInto;
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::form_urlencoded::Serializer;
 
-fn encode_base64(input: String) -> String {
-    general_purpose::STANDARD.encode(input)
+fn base64_encode(input: String) -> String {
+    general_purpose::URL_SAFE_NO_PAD.encode(input)
 }
 
 pub fn authorization_request<ReqUri, RedirectUri>(
@@ -45,7 +45,7 @@ where
 
     let body = match &auth.scheme {
         AuthenticationScheme::Basic(client_credentials) => {
-            let basic = encode_base64(format!(
+            let basic = base64_encode(format!(
                 "{}:{}",
                 &auth.client_id, client_credentials.client_secret
             ));
@@ -173,7 +173,7 @@ where
     serializer.append_pair("client_id", &auth.client_id);
     let body = match &auth.scheme {
         AuthenticationScheme::Basic(client_credentials) => {
-            let basic = encode_base64(format!(
+            let basic = base64_encode(format!(
                 "{}:{}",
                 &auth.client_id, client_credentials.client_secret
             ));
@@ -254,7 +254,7 @@ where
     partial.append_pair("client_id", &auth.client_id);
     let body = match &auth.scheme {
         AuthenticationScheme::Basic(client_credentials) => {
-            let basic = encode_base64(format!(
+            let basic = base64_encode(format!(
                 "{}:{}",
                 &auth.client_id, client_credentials.client_secret
             ));
@@ -297,7 +297,7 @@ mod test {
 
         let result = authorization_request(uri, redirect_uri, &auth, &scopes).unwrap();
 
-        let body = str::from_utf8(&result.body()).unwrap();
+        let body = str::from_utf8(result.body()).unwrap();
         assert_eq!(body, "redirect_uri=https%3A%2F%2Fexample.com%2Fredirect&grant_type=authorization_code&response_type=code&scope=openid&client_id=some-client-id");
 
         let auth_header = result

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -350,37 +350,32 @@ mod test {
             "authorization_endpoint": "https://auth.example.com/oauth2/authorize",
             "token_endpoint": "https://auth.example.com/oauth2/token",
             "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
-            "scopes_supported": [
-                "ascope",
-                "play"
-            ],
-            "response_types_supported": [
-                "code",
-                "token"
-            ],
-            "claims_supported": [
-                "aud",
-                "exp",
-                "ext",
-                "iat",
-                "iss",
-                "jti",
-                "nbf",
-                "scp",
-                "sub",
-                "client_id",
-                "ext_provider_id",
-                "company"
-            ],
-            "grant_types_supported": [
-                "authorization_code",
-                "refresh_token",
-                "client_credentials"
-            ]
+            "scopes_supported": ["some-scope"],
+            "response_types_supported": ["some-response-type"],
+            "claims_supported": ["some-claim"],
+            "grant_types_supported": ["some-type"]
         }"#;
 
         let response = Response::new(json.as_bytes());
-        let _provider = Provider::from_response(response).unwrap();
+        let provider = Provider::from_response(response).unwrap();
+        assert_eq!(
+            "https://auth.example.com/oauth2/token",
+            provider.token_endpoint.unwrap(),
+        );
+        assert_eq!(None, provider.userinfo_endpoint);
+        assert_eq!(provider.issuer, "https://auth.example.com/");
+        assert_eq!(
+            provider.authorization_endpoint,
+            "https://auth.example.com/oauth2/authorize"
+        );
+        assert_eq!(
+            provider.jwks_uri,
+            "https://auth.example.com/.well-known/jwks.json"
+        );
+        assert_eq!(provider.scopes_supported[0], "some-scope");
+        assert_eq!(provider.response_types_supported[0], "some-response-type");
+        assert_eq!(provider.claims_supported[0], "some-claim");
+        assert_eq!(provider.grant_types_supported[0], "some-type");
     }
 
     #[test]
@@ -392,32 +387,13 @@ mod test {
             "token_endpoint": "https://auth.example.com/oauth2/token",
             "jwks_uri": "https://auth.example.com/.well-known/jwks.json",
             "userinfo_endpoint": "https://auth.example.com/userinfo",
-            "scopes_supported": [
-                "ascope",
-                "play"
-            ],
-            "response_types_supported": [
-                "code",
-                "token"
-            ],
+            "scopes_supported": [],
+            "response_types_supported": [],
             "claims_supported": [
-                "aud",
-                "exp",
-                "ext",
-                "iat",
-                "iss",
-                "jti",
-                "nbf",
-                "scp",
-                "sub",
-                "client_id",
-                "ext_provider_id",
-                "company"
+                "aud"
             ],
             "grant_types_supported": [
-                "authorization_code",
-                "refresh_token",
-                "client_credentials"
+                "refresh_token"
             ]
         }"#;
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Upgrade base64 0.13 to 0.21
Use `URL_SAFE_NO_PAD` for base64 encoding
Upgrade tokio (used by the examples) from 1.21 to 1.28
Add tests for `Provider` and new de-serializer for optional fields

Use https://github.com/EmbarkStudios/jsonwebtoken/tree/fix/pem-2.0 while waiting for https://github.com/Keats/jsonwebtoken/pull/303 to get merged. We need the updated pem library in order to use `base64 0.21`
