### PR TITLE
Set audience validation default to off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-## [0.7.0] - Unreleased
+## [x.x.x] - Unreleased
+
+## [0.7.0] - 2023-12-19
 ### Changed
 - Change default behaviour back since updating `jsonwebtoken` to `0.9x` to client-based audience validation 
 instead of library audience-validation. IE. The user validates their own `aud`, if wanted.    

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-## [Unreleased] - ReleaseDate
+## [0.6.2] - Unreleased
+## Changed
+- Change default behaviour back since updating `jsonwebtoken` to `0.9x` to client-based audience validation 
+instead of library audience-validation. IE. The user validates their own `aud`, if wanted.    
+
+## [0.6.1] - 2023-10-25
 ## Changed
 - [PR#23](https://github.com/EmbarkStudios/tame-oidc/pull/23) replaced `base64` with `data-encoding`
 - [PR#24](https://github.com/EmbarkStudios/tame-oidc/pull/24) upgraded `ring` from 0.16 -> 0.17.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!-- next-header -->
-## [0.6.2] - Unreleased
-## Changed
+## [0.7.0] - Unreleased
+### Changed
 - Change default behaviour back since updating `jsonwebtoken` to `0.9x` to client-based audience validation 
 instead of library audience-validation. IE. The user validates their own `aud`, if wanted.    
+- Make userinfo-endpoint on `Provider` optional as it's `RECOMMENDED` according to the oidc-spec.
+
+### Fixed
+- Fix a bug where secret wasn't passed through if using the `PKCE`-flow with a client-secret
 
 ## [0.6.1] - 2023-10-25
-## Changed
+### Changed
 - [PR#23](https://github.com/EmbarkStudios/tame-oidc/pull/23) replaced `base64` with `data-encoding`
 - [PR#24](https://github.com/EmbarkStudios/tame-oidc/pull/24) upgraded `ring` from 0.16 -> 0.17.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tame-oidc"
 description = "A (very) thin layer of OIDC like functionality"
-version = "0.6.2"
+version = "0.7.0"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Mathias Tervo <mathias.tervo@embark-studios.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tame-oidc"
 description = "A (very) thin layer of OIDC like functionality"
-version = "0.6.1"
+version = "0.6.2"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Mathias Tervo <mathias.tervo@embark-studios.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,8 @@ doctest = false
 path = "src/lib.rs"
 
 [[example]]
-name = "embark"
-path = "examples/embark.rs"
+name = "embark-pkce"
+path = "examples/embark-pkce.rs"
 
 [dependencies]
 data-encoding = "2.4"
@@ -33,6 +33,8 @@ thiserror = "1"
 ## dev dependencies below
 [dev-dependencies]
 bytes = "1.4"
+rand = "0.8.5"
+ring = "0.17.7"
 
 [dev-dependencies.reqwest]
 version = "0.11.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tame-oidc"
 description = "A (very) thin layer of OIDC like functionality"
-version = "0.5.0"
+version = "0.6.1"
 authors = [
     "Embark <opensource@embark-studios.com>",
     "Mathias Tervo <mathias.tervo@embark-studios.com>",
@@ -24,7 +24,7 @@ path = "examples/embark.rs"
 [dependencies]
 data-encoding = "2.4"
 http = "0.2"
-jsonwebtoken = "9.1"
+jsonwebtoken = "9.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 url = "2.3"
@@ -32,13 +32,13 @@ thiserror = "1"
 
 ## dev dependencies below
 [dev-dependencies]
-bytes = "1.2"
+bytes = "1.4"
 
 [dev-dependencies.reqwest]
-version = "0.11"
+version = "0.11.22"
 features = ["rustls-tls"]
 default-features = false
 
 [dev-dependencies.tokio]
-version = "1.21"
+version = "1.35.0"
 features = ["macros", "rt-multi-thread"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/lib.rs"
 name = "embark-pkce"
 path = "examples/embark-pkce.rs"
 
+[[example]]
+name = "embark-basic"
+path = "examples/embark-basic.rs"
+
 [dependencies]
 data-encoding = "2.4"
 http = "0.2"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See example code in `examples/embark.rs`
 
 ## Examples
 
-### [embark](examples/embark.rs)
+### [embark pkce](examples/embark-pkce)
 
 Usage: `cargo run --example embark`
 

--- a/README.md
+++ b/README.md
@@ -32,11 +32,20 @@ See example code in `examples/embark.rs`
 
 ## Examples
 
+### [embark basic](examples/embark-basic)
+
+Usage: `cargo run --example embark-basic`
+
+A small example of using `tame-oidc` together with [reqwest](https://github.com/seanmonstar/reqwest) using 
+the basic auth flow.
+
+
 ### [embark pkce](examples/embark-pkce)
 
-Usage: `cargo run --example embark`
+Usage: `cargo run --example embark-pkce`
 
-A small example of using `tame-oidc` together with [reqwest](https://github.com/seanmonstar/reqwest).
+A small example of using `tame-oidc` together with [reqwest](https://github.com/seanmonstar/reqwest) using the PKCE 
+auth flow.
 
 ## Contributing
 

--- a/examples/embark-basic.rs
+++ b/examples/embark-basic.rs
@@ -9,9 +9,7 @@ use std::{
     net::{TcpListener, TcpStream},
     str,
 };
-use tame_oidc::auth_scheme::{
-    AuthenticationScheme, ClientAuthentication, ClientCredentials,
-};
+use tame_oidc::auth_scheme::{AuthenticationScheme, ClientAuthentication, ClientCredentials};
 use tame_oidc::provider::Claims;
 use tame_oidc::{
     oidc::Token,

--- a/examples/embark-pkce.rs
+++ b/examples/embark-pkce.rs
@@ -2,6 +2,8 @@
 
 use bytes::Bytes;
 use http::Request;
+use rand::rngs::ThreadRng;
+use rand::RngCore;
 use reqwest::Url;
 use std::{
     convert::TryInto,
@@ -9,7 +11,7 @@ use std::{
     net::{TcpListener, TcpStream},
     str,
 };
-use tame_oidc::auth_scheme::{AuthenticationScheme, ClientAuthentication, ClientCredentials};
+use tame_oidc::auth_scheme::{AuthenticationScheme, ClientAuthentication, PkceCredentials};
 use tame_oidc::provider::Claims;
 use tame_oidc::{
     oidc::Token,
@@ -39,9 +41,10 @@ fn handle_connection(mut stream: TcpStream) -> Option<String> {
 
 /// Spins up a listener on port, waits for any request from
 /// the authentication provider and tries to return an `auth_code`
-async fn listener(redirect_uri: &str) -> String {
-    let listener = TcpListener::bind(redirect_uri).unwrap();
-    println!("Listening on {}", redirect_uri);
+async fn listener(host: &str, port: u16) -> String {
+    let urn = format!("{host}:{port}");
+    let listener = TcpListener::bind(&urn).unwrap();
+    println!("Listening on {}", urn);
 
     let mut auth_code = String::new();
     for stream in listener.incoming() {
@@ -76,30 +79,62 @@ async fn http_send<Body: Into<reqwest::Body>>(
 #[tokio::main]
 async fn main() {
     let http_client = reqwest::Client::new();
+    let mut rng = ThreadRng::default();
+    let mut state = [0u8; 64];
+    rng.fill_bytes(&mut state);
+    let state_str = data_encoding::BASE64URL.encode(&state);
+
+    let mut verifier = [0u8; 32];
+    rng.fill_bytes(&mut verifier);
+    let verifier_str = data_encoding::BASE64URL_NOPAD.encode(&verifier);
+    let challenge_digest = ring::digest::digest(&ring::digest::SHA256, verifier_str.as_bytes());
+    let challenge = data_encoding::BASE64URL_NOPAD.encode(challenge_digest.as_ref());
+    let challenge_method = "S256".to_string();
 
     let issuer_domain = std::env::var("ISSUER_DOMAIN").unwrap();
-    let client_secret = std::env::var("CLIENT_SECRET").unwrap();
+    // Secret is optional in the PKCE flow
+    let client_secret = std::env::var("CLIENT_SECRET").ok();
     let client_id = std::env::var("CLIENT_ID").unwrap();
-    let redirect_uri = "127.0.0.1:8000";
+    let host = "127.0.0.1";
+    let port = 8000u16;
+    // It's very important that this exactly matches where it's provided in other places, protocol and trailing slash all
+    let redirect_uri = format!("http://{host}:{port}/");
 
     // Fetch and instantiate a provider using a `well-known` uri from an issuer
     let request = provider::well_known(&issuer_domain).unwrap();
     let response = http_send(&http_client, request).await;
     let provider = Provider::from_response(response).unwrap();
-
+    let auth_endpoint = provider.authorization_endpoint.to_string();
     // 1. Authenticate through web browser
     // user goes to embark auth url in browser
     // auth service returns auth_code to listener at `redirect_uri`
-    let auth_code = listener(redirect_uri).await;
+    // Add idp-specific extra query-parameters to the below `authorize_url`
+    let authorize_url = format!(
+        "{auth_endpoint}?\
+code_challenge={challenge}&\
+code_challenge_method=S256&\
+response_type=code&\
+client_id={client_id}&\
+redirect_uri={redirect_uri}&\
+state={state_str}",
+    );
+    println!("Authorize at {authorize_url}");
+
+    let auth_code = listener(host, port).await;
     println!("Listener closed down");
     println!("Final code {}", auth_code);
 
     // 3. User now has 2 minutes to swap the auth code for an Embark Access token.
     // Make a `POST` request to the auth service /oauth2/token
-    let scheme = AuthenticationScheme::Basic(ClientCredentials::new(client_secret));
+    let scheme = AuthenticationScheme::Pkce(PkceCredentials::new(
+        challenge.clone(),
+        challenge_method.clone(),
+        verifier_str.clone(),
+        client_secret.clone(),
+    ));
     let client_authentication = ClientAuthentication::new(client_id, scheme, None, None);
     let exchange_request = provider
-        .exchange_token_request(redirect_uri, &client_authentication, &auth_code)
+        .exchange_token_request(&redirect_uri, &client_authentication, &auth_code)
         .unwrap();
 
     let response = http_send(&http_client, exchange_request).await;

--- a/src/deserialize_uri.rs
+++ b/src/deserialize_uri.rs
@@ -1,6 +1,8 @@
 use http::Uri;
+use serde::de::Error;
 use serde::{de, Deserializer};
 use std::fmt;
+use std::fmt::Formatter;
 
 struct UriVisitor;
 impl<'de> de::Visitor<'de> for UriVisitor {
@@ -21,4 +23,37 @@ where
     D: Deserializer<'de>,
 {
     de.deserialize_str(UriVisitor)
+}
+
+struct OptUriVisitor;
+
+impl<'de> de::Visitor<'de> for OptUriVisitor {
+    type Value = Option<Uri>;
+
+    fn expecting(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        write!(formatter, "valid or missing uri")
+    }
+
+    #[inline]
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(Some(UriVisitor.visit_str(v)?))
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: Error,
+    {
+        Ok(None)
+    }
+
+}
+
+pub fn deserialize_opt<'de, D>(de: D) -> Result<Option<Uri>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    de.deserialize_str(OptUriVisitor)
 }

--- a/src/deserialize_uri.rs
+++ b/src/deserialize_uri.rs
@@ -48,7 +48,6 @@ impl<'de> de::Visitor<'de> for OptUriVisitor {
     {
         Ok(None)
     }
-
 }
 
 pub fn deserialize_opt<'de, D>(de: D) -> Result<Option<Uri>, D::Error>

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -24,6 +24,9 @@ pub enum OidcValidationError {
     #[error("Nonce doesn't match initially provided nonce")]
     NonceMismatch,
 
+    #[error("Provider did not contain a userinfo endpoint")]
+    NoUserEndpoint,
+
     #[error("Sub from user data doesn't match sub from token data")]
     UserMismatch,
 

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -221,6 +221,7 @@ where
     let (parts, body) = response.into_parts();
 
     if !parts.status.is_success() {
+        println!("{:?}", core::str::from_utf8(body.as_ref()));
         return Err(Error::HttpStatus(parts.status));
     }
 

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -261,11 +261,16 @@ where
                 .append_pair("client_secret", &client_credentials.client_secret)
                 .finish(),
         )),
-        AuthenticationScheme::Pkce(pkce) => request_builder.body(Vec::from(
-            partial
-                .append_pair("code_verifier", &pkce.code_verifier)
-                .finish(),
-        )),
+        AuthenticationScheme::Pkce(pkce) => {
+            if let Some(client_secret) = &pkce.client_secret {
+                partial.append_pair("client_secret", client_secret);
+            }
+            request_builder.body(Vec::from(
+                partial
+                    .append_pair("code_verifier", &pkce.code_verifier)
+                    .finish(),
+            ))
+        }
     }?;
     Ok(body)
 }

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -235,6 +235,7 @@ where
 {
     let mut validation = Validation::default();
     validation.algorithms = vec![Algorithm::RS256, Algorithm::RS384, Algorithm::RS512];
+    validation.validate_aud = false;
 
     decode::<CLAIMS>(
         token,

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -19,8 +19,8 @@ pub struct Provider {
     pub token_endpoint: Uri,
     #[serde(with = "crate::deserialize_uri")]
     pub jwks_uri: Uri,
-    #[serde(with = "crate::deserialize_uri")]
-    pub userinfo_endpoint: Uri,
+    #[serde(default, deserialize_with = "crate::deserialize_uri::deserialize_opt")]
+    pub userinfo_endpoint: Option<Uri>,
     pub scopes_supported: Vec<String>,
     pub response_types_supported: Vec<String>,
     pub claims_supported: Vec<String>,
@@ -112,8 +112,13 @@ impl Provider {
         refresh_token_request(&self.token_endpoint, auth, refresh_token)
     }
 
-    pub fn user_info_request(&self, access_token: &str) -> Result<Request<Vec<u8>>, RequestError> {
-        user_info_request(&self.userinfo_endpoint, access_token)
+    pub fn user_info_request(
+        &self,
+        access_token: &str,
+    ) -> Option<Result<Request<Vec<u8>>, RequestError>> {
+        self.userinfo_endpoint
+            .as_ref()
+            .map(|uri| user_info_request(uri, access_token))
     }
 
     pub fn jwks_request(&self) -> Result<Request<Vec<u8>>, RequestError> {

--- a/src/strict.rs
+++ b/src/strict.rs
@@ -213,6 +213,7 @@ impl UserInfoStage {
     pub fn generate_fetch_request(&self) -> Result<Request<Vec<u8>>, Error> {
         self.provider
             .user_info_request(&self.token.access_token)
+            .ok_or(Error::OidcValidation(OidcValidationError::NoUserEndpoint))?
             .map_err(|e| e.into())
     }
 


### PR DESCRIPTION
### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Since `jsonwebtoken 9x` audience is validated by default. The library's validation of that token is [itself finicky](https://github.com/Keats/jsonwebtoken/pull/350) since audience can be provided in multiple (valid) ways. To avoid creating production incidents because of unexpected upstream library's parsing strategy, audience-validation will default to off as in `8.x`, then the client gets the responsibility to validate audience after decoding. 

~~Whether this should be considered a major-version bump or bugfix is debatable. If this audience validation change is considered a bug, then this is a bugfix from a bug introduced in `0.6.1` if that's not considered a bug then `0.6.1` should have been `0.7.0` and this should be `0.8.0`, I'm leaning towards this being a bugfix since this behaviour was not intended, placing us at `0.6.2`.~~

~~Drive-by fixing the changelog and `toml` version.~~

There was some spec-noncompliance where userinfo-endpoint was required although the spec says recommended, made that optional, causing this to be a major version bump anyway.

Also found a bug in the `PKCE`+client-secret flow that was fixed up.

Fixed the examples by duplicating them, one for basic auth and one for PKCE, they are now both up-to-date and hopefully a bit easier to understand.