### PR TITLE
Update http dependency to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [x.x.x] - Unreleased
+- Update `http` to 1.x
 
 ## [0.7.0] - 2023-12-19
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ path = "examples/embark-basic.rs"
 
 [dependencies]
 data-encoding = "2.4"
-http = "0.2"
+http = "1"
 jsonwebtoken = "9.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -41,7 +41,7 @@ rand = "0.8.5"
 ring = "0.17.7"
 
 [dev-dependencies.reqwest]
-version = "0.11.22"
+version = "0.12.1"
 features = ["rustls-tls"]
 default-features = false
 


### PR DESCRIPTION

### Checklist

* [x] I have read the [Contributor Guide](../../CONTRIBUTING.md)
* [x] I have read and agree to the [Code of Conduct](../../CODE_OF_CONDUCT.md)
* [x] I have added a description of my changes and why I'd like them included in the section below

### Description of Changes

Updates to the stabilized version 1 of `http` crate. Also updates `reqwest` dev-dependency to 0.12, which is compatible with `http` 1.x.
This makes `tame-oidc` compatible with `reqwest` 0.12+.
